### PR TITLE
validation at compile time

### DIFF
--- a/recap-derive/Cargo.toml
+++ b/recap-derive/Cargo.toml
@@ -20,6 +20,7 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "softprops/recap" }
 
 [dependencies]
-quote = "0.6"
-syn = "0.15"
 proc-macro2 = "0.4"
+quote = "0.6"
+regex = "1.1"
+syn = "0.15"

--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -75,7 +75,7 @@ fn validate(
     };
     if caps != fields {
         panic!(
-            "Recap could not derive a `FromStr` impl for `{}`.\n\t\t > Expected regex with {:?} named capture groups but found {:?}",
+            "Recap could not derive a `FromStr` impl for `{}`.\n\t\t > Expected regex with {} named capture groups but found {}",
             item.ident, fields, caps
         );
     }

--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -3,7 +3,11 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Ident, Lit, Meta, NestedMeta};
+use regex::Regex;
+use std::convert::identity;
+use syn::{
+    parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta,
+};
 
 #[proc_macro_derive(Recap, attributes(recap))]
 pub fn derive_recap(item: TokenStream) -> TokenStream {
@@ -16,6 +20,9 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
             struct YourStruct { ... }
             "#,
     );
+
+    validate(&item, &regex);
+
     let item_ident = &item.ident;
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
@@ -46,6 +53,32 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
     };
 
     out.into()
+}
+
+fn validate(
+    item: &DeriveInput,
+    regex: &str,
+) {
+    let regex = Regex::new(&regex).unwrap_or_else(|err| {
+        panic!(
+            "Invalid regular expression provided for `{}`\n{}",
+            &item.ident, err
+        )
+    });
+    let caps = regex.capture_names().filter_map(identity).count();
+    let fields = match &item.data {
+        Struct(DataStruct {
+            fields: Fields::Named(fs),
+            ..
+        }) => fs.named.len(),
+        _ => panic!("Recap regex can only be applied to Structs with named fields"),
+    };
+    if caps != fields {
+        panic!(
+            "Recap could not derive a `FromStr` impl for `{}`.\n\t\t > Expected regex with {:?} named capture groups but found {:?}",
+            item.ident, fields, caps
+        );
+    }
 }
 
 fn extract_regex(item: &DeriveInput) -> Option<String> {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #5

mvp to leverage opportunity for compile time safety for ensuring at the very least

* we're deriving for a struct with named fields
* provided regex is valid
* regex has the same number of captures as the the struct has fields

#### How did you verify your change:

change example to break regex and to remove capture groups.  it won't compile if invalid as we intend it not to!

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

tighten developer feedback loop by ensuring regex correctness at compile time.