### PR TITLE
Update to proc-macro2, quote, and syn 1

### DIFF
--- a/recap-derive/Cargo.toml
+++ b/recap-derive/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "softprops/recap" }
 
 [dependencies]
-proc-macro2 = "0.4"
-quote = "0.6"
+proc-macro2 = "1"
+quote = "1"
 regex = "1.2"
-syn = "0.15"
+syn = "1"

--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -104,7 +104,7 @@ fn extract_regex(item: &DeriveInput) -> Option<String> {
             Meta::List(y) => Some(y),
             _ => None,
         })
-        .filter(|x| x.ident == "recap")
+        .filter(|x| x.path.is_ident("recap"))
         .flat_map(|x| x.nested.into_iter())
         .filter_map(|x| match x {
             NestedMeta::Meta(y) => Some(y),
@@ -114,7 +114,7 @@ fn extract_regex(item: &DeriveInput) -> Option<String> {
             Meta::NameValue(y) => Some(y),
             _ => None,
         })
-        .find(|x| x.ident == "regex")
+        .find(|x| x.path.is_ident("regex"))
         .and_then(|x| match x.lit {
             Lit::Str(y) => Some(y.value()),
             _ => None,


### PR DESCRIPTION
## What did you implement:

The `proc-macro2`, `quote`, and `syn` dependencies of `recap-derive` have all been updated to version 1.

#### How did you verify your change:

Ran `cargo build` and `cargo test` locally with stable Rust.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

These crates migrated to Rust 2018, so they now require at least Rust 1.31. But I see that recap was already on 2018, so there's no change to recap users here. So for the CHANGELOG, this is just a minor maintenance update.

It may help users avoid duplicate syn/etc. in their build tree, which is what motivated me.