### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.1.2
 
 * Introduce derived `pub fn is_match(txt: &str) -> bool` associated fn on proc macro'd struct
+* Update proc-macro dependencies to stable version 1
 
 # 0.1.1
 

--- a/recap/Cargo.toml
+++ b/recap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recap"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["softprops <d.tangren@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
## What did you implement:

Bumped `recap` to 0.1.2, in sync with `recap-derive`.
(Both have only published 0.1.1 so far.)

#### How did you verify your change:

Skimmed the git history since 0.1.1 to see what has changed.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

There was already a note for `pub fn is_match`, and I added a note on proc-macro dependencies (#8).