### PR TITLE
Resolve Clippy warnings with Rust 1.52.1

### DIFF
--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -4,7 +4,6 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
 use regex::Regex;
-use std::convert::identity;
 use syn::{
     parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta,
 };
@@ -37,7 +36,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                             .expect("Failed to compile regex");
                     }
 
-                    Ok(recap::from_captures(&RE, s)?)
+                    recap::from_captures(&RE, s)
                 }
             }
         }
@@ -56,7 +55,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                         .expect("Failed to compile regex");
                 }
 
-                Ok(recap::from_captures(&RE, s)?)
+                recap::from_captures(&RE, s)
             }
         }
         #impl_from_str
@@ -102,7 +101,7 @@ fn validate(
             &item.ident, err
         )
     });
-    let caps = regex.capture_names().filter_map(identity).count();
+    let caps = regex.capture_names().flatten().count();
     let fields = match &item.data {
         Struct(DataStruct {
             fields: Fields::Named(fs),

--- a/recap/src/lib.rs
+++ b/recap/src/lib.rs
@@ -112,7 +112,6 @@ use serde::de::{
     value::{BorrowedStrDeserializer, MapDeserializer, SeqDeserializer},
     Deserialize, IntoDeserializer,
 };
-use std::convert::identity;
 
 // used in derive crate output
 // to derive a static for compiled
@@ -365,7 +364,7 @@ where
             .map(|maybe_name| {
                 maybe_name.and_then(|name| caps.name(name).map(|val| (name, val.as_str())))
             })
-            .filter_map(identity),
+            .flatten(),
     )
 }
 


### PR DESCRIPTION
## What did I implement:

Fixed two type of Clippy warnings using Rust 1.52.1.

#### How did you verify your change:

Upgrade Rust version to 1.52.1 and run `cargo clippy --all-targets`. You'll get two different types of warning:

This is just an internal warning
```
warning: called `filter_map(std::convert::identity)` on an `Iterator`
   --> recap-derive/src/lib.rs:105:38
    |
105 |     let caps = regex.capture_names().filter_map(identity).count();
    |                                      ^^^^^^^^^^^^^^^^^^^^ help: try: `flatten()`
```

`Recap` macro expands and the one who uses this lib receive this warning too
```
warning: question mark operator is useless here
 --> recap/examples/log.rs:5:30
  |
5 | #[derive(Debug, Deserialize, Recap)]
```
