### PR TITLE
Remove useless question mark operator

### DIFF
--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -37,7 +37,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                             .expect("Failed to compile regex");
                     }
 
-                    Ok(recap::from_captures(&RE, s)?)
+                    recap::from_captures(&RE, s)
                 }
             }
         }
@@ -56,7 +56,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                         .expect("Failed to compile regex");
                 }
 
-                Ok(recap::from_captures(&RE, s)?)
+                recap::from_captures(&RE, s)
             }
         }
         #impl_from_str


### PR DESCRIPTION
## What did you implement:
Just removed a redundant question mark operator. Got annoyed by clippy complaints! 
<img width="325" alt="image" src="https://user-images.githubusercontent.com/5764201/146280309-f4a0d753-1529-49f2-865a-677d9534dde7.png">

#### How did you verify your change:
Test passing.
