### PR TITLE
Enabled composed/nested structs by impl'ing Deserialize ourselves

### DIFF
--- a/recap-derive/src/impl_deserialize.rs
+++ b/recap-derive/src/impl_deserialize.rs
@@ -1,0 +1,237 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{Data::Struct, DeriveInput, Meta};
+
+/// Takes over implementing [serde::Deserialize] for the struct we're deriving Recap on.
+///
+/// The main motivation here is to allow nested uses of Recap-based deserialization, namely teaching
+/// the Deserialize implementation (or more specifically the Visitor implementation within that)
+/// how to handle a string.
+///
+/// We can't just add an extra `visit_str` implementation to the existing code that gets generated
+/// by `#[derive(Deserialize)]` since proc macros can't be nested (can't see/modify the output of
+/// other proc macros). But we also don't want to fully re-implement deriving `Deserialize`. So the
+/// approach taken here is to generate a hidden inner struct (called `__DeserializeHelper`) with all
+/// the same fields and serde attributes and slap a `#[derive(Deserialize)]` on *that*. Our
+/// implementation of `Deserialize` will then:
+///
+/// - Forward the deserialize call to `__DeserializeHelper` for most types of data, moving the
+///     fields into an instance of the actual struct once done.
+/// - Have a `visit_str` method that knows how to use the given regex to parse the str into
+///     capture groups and *then* forward that to `__DeserializeHelper` as above.
+///
+/// However this is a breaking change, since previously it was expected that you'd
+/// put `#[derive(Deserialize, Recap)]` on your struct. Therefore it needs to be opted into with
+/// the `#[recap(handle_deserialize)]` attribute (which can also be combined with the `regex = ...`
+/// attribute on a single line) to opt into this.
+pub fn derive_impl_deserialize(
+    item: &DeriveInput,
+    item_ident: &Ident,
+    nested_metas: Vec<Meta>,
+    regex: String,
+) -> TokenStream {
+    let include_deserialize_impl = nested_metas
+        .iter()
+        .any(|meta| meta.path().is_ident("handle_deserialize"));
+    if !include_deserialize_impl {
+        return quote!();
+    }
+
+    // Make a copy of the struct with a different name (`__DeserializeHelper`) and without
+    // any recap attributes.
+    let deserialize_helper_ident = Ident::new("__DeserializeHelper", Span::call_site());
+    let mut deserialize_helper_item = item.clone();
+    deserialize_helper_item.ident = deserialize_helper_ident.clone();
+    deserialize_helper_item
+        .attrs
+        .retain(|attr| !attr.path.is_ident("recap"));
+    match &mut deserialize_helper_item.data {
+        Struct(data_struct) => {
+            for field in data_struct.fields.iter_mut() {
+                field.attrs.retain(|attr| !attr.path.is_ident("recap"));
+            }
+        }
+        _ => panic!("Expected Recap derive on struct only"),
+    }
+
+    // Figure out the field names so we can move them from the helper struct to the real one
+    let assign_fields = match &item.data {
+        Struct(data_struct) => data_struct
+            .fields
+            .iter()
+            .flat_map(|field| {
+                field.ident.as_ref().map(|field_ident| {
+                    quote! {
+                        #field_ident: value.#field_ident,
+                    }
+                })
+            })
+            .collect::<Vec<_>>(),
+        _ => panic!("Expected Recap derive on struct only"),
+    };
+    // Needed for the Visitor implementation
+    let visitor_expecting = format!("struct {}", item.ident);
+    let visitor_forward_methods = vec![
+        visitor_forward_primitive("bool", &deserialize_helper_ident),
+        visitor_forward_primitive("i8", &deserialize_helper_ident),
+        visitor_forward_primitive("i16", &deserialize_helper_ident),
+        visitor_forward_primitive("i32", &deserialize_helper_ident),
+        visitor_forward_primitive("i64", &deserialize_helper_ident),
+        visitor_forward_primitive("i128", &deserialize_helper_ident),
+        visitor_forward_primitive("u8", &deserialize_helper_ident),
+        visitor_forward_primitive("u16", &deserialize_helper_ident),
+        visitor_forward_primitive("u32", &deserialize_helper_ident),
+        visitor_forward_primitive("u64", &deserialize_helper_ident),
+        visitor_forward_primitive("u128", &deserialize_helper_ident),
+        visitor_forward_primitive("f32", &deserialize_helper_ident),
+        visitor_forward_primitive("f64", &deserialize_helper_ident),
+        visitor_forward_primitive("char", &deserialize_helper_ident),
+        visitor_forward_deserializer("some", &deserialize_helper_ident),
+        visitor_forward_deserializer("newtype_struct", &deserialize_helper_ident),
+        visitor_forward_accessor("seq", &deserialize_helper_ident),
+        visitor_forward_accessor("map", &deserialize_helper_ident),
+        visitor_forward_accessor("enum", &deserialize_helper_ident),
+    ];
+
+    quote! {
+        extern crate serde as _serde;
+        #[derive(_serde::Deserialize)]
+        #deserialize_helper_item
+
+        impl From<#deserialize_helper_ident> for #item_ident {
+            fn from(value: #deserialize_helper_ident) -> Self {
+                Self {
+                    #(#assign_fields)*
+                }
+            }
+        }
+
+        impl<'de> _serde::Deserialize<'de> for #item_ident {
+            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: _serde::Deserializer<'de>,
+            {
+                struct __Visitor<'de> {
+                    marker: std::marker::PhantomData<#item_ident>,
+                    lifetime: std::marker::PhantomData<&'de ()>,
+                }
+                impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                    type Value = #item_ident;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter,
+                    ) -> std::fmt::Result {
+                        formatter.write_str(#visitor_expecting)
+                    }
+
+                    #(#visitor_forward_methods)*
+
+                    fn visit_str<E>(
+                        self,
+                        v: &str,
+                    ) -> core::result::Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        recap::lazy_static! {
+                            static ref RE: recap::Regex = recap::Regex::new(#regex)
+                                .expect("Failed to compile regex");
+                        }
+                        recap::from_captures::<#deserialize_helper_ident>(&RE, v)
+                            .map(|helper| helper.into())
+                            .map_err(|e| serde::de::Error::custom(e))
+                    }
+                }
+
+                deserializer.deserialize_any(__Visitor {
+                    marker: std::marker::PhantomData::<#item_ident>,
+                    lifetime: std::marker::PhantomData,
+                })
+            }
+        }
+    }
+}
+
+/*
+Helpers for forwarding the deserialize call to the struct that derives Deserialize. Broadly they
+convert the given data into a deserializer, call deserialize, and convert the resulting data into
+our desired struct.
+*/
+
+fn visitor_forward_primitive(
+    primitive_name: &str,
+    target: &Ident,
+) -> TokenStream {
+    let method_ident = Ident::new(&format!("visit_{}", primitive_name), Span::call_site());
+    let primitive_ident = Ident::new(primitive_name, Span::call_site());
+
+    quote! {
+        fn #method_ident<E>(
+            self,
+            v: #primitive_ident,
+        ) -> Result<Self::Value, E>
+        where
+            E: _serde::de::Error,
+        {
+            let deserializer =
+                <#primitive_ident as _serde::de::IntoDeserializer>::into_deserializer(v);
+            <#target as _serde::Deserialize>::deserialize(deserializer)
+                .map(|helper| helper.into())
+                // Can't figure out how to get the compiler to infer this error type as the return, so just wrap it
+                .map_err(|e| _serde::de::Error::custom(e))
+        }
+    }
+}
+
+fn visitor_forward_deserializer(
+    name: &str,
+    target: &Ident,
+) -> TokenStream {
+    let method_ident = Ident::new(&format!("visit_{}", name), Span::call_site());
+
+    quote! {
+        fn #method_ident<D>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error>
+        where
+            D: _serde::Deserializer<'de>,
+        {
+            <#target as _serde::Deserialize>::deserialize(deserializer).map(|helper| helper.into())
+        }
+    }
+}
+
+// Handles the visit_map, visit_seq, and visit_enum, along with the corresponding
+// (Map|Seq|Enum)Access and (Map|Seq|Enum)AccessDeserializer types.
+fn visitor_forward_accessor(
+    type_name: &str,
+    target: &Ident,
+) -> TokenStream {
+    let method_ident = Ident::new(&format!("visit_{}", type_name), Span::call_site());
+    let capitalized_type_name = format!("{}{}", type_name[0..1].to_uppercase(), &type_name[1..]);
+    let accessor_ident = Ident::new(
+        &format!("{}Access", capitalized_type_name),
+        Span::call_site(),
+    );
+    let accessor_deserializer_ident = Ident::new(
+        &format!("{}AccessDeserializer", capitalized_type_name),
+        Span::call_site(),
+    );
+
+    quote! {
+        fn #method_ident<A>(
+            self,
+            v: A,
+        ) -> Result<Self::Value, A::Error>
+        where
+            A: _serde::de::#accessor_ident<'de>,
+        {
+            <#target as _serde::Deserialize>::deserialize(
+                <_serde::de::value::#accessor_deserializer_ident<A>>::new(v),
+            )
+            .map(|helper| helper.into())
+        }
+    }
+}

--- a/recap/Cargo.toml
+++ b/recap/Cargo.toml
@@ -26,3 +26,6 @@ serde = { version = "1.0", features = ["derive"] }
 [features]
 default = ["derive"]
 derive = ["recap-derive"]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/recap/src/lib.rs
+++ b/recap/src/lib.rs
@@ -2,7 +2,7 @@
 //! extracted from strings.
 //!
 //! You may find this crate useful for cases where input is provided as a raw string in a loosely structured format.
-//! A common use case for this is when you're dealing with log file data that was not stored in a particular structed format
+//! A common use case for this is when you're dealing with log file data that was not stored in a particular structured format
 //! like JSON but rather in a format that can be represented with a pattern.
 //!
 //! Recap is provides what [envy](https://crates.io/crates/envy) provides environment variables for named regex capture groups
@@ -70,7 +70,7 @@
 //! ```
 //!
 //! You can also use recap by using the generic function `from_captures` in which
-//! case you'll be reponsible for bringing your only Regex reference.
+//! case you'll be responsible for bringing your only Regex reference.
 //!
 //! 💡 For convenience the [regex](https://crates.io/crates/regex) crate's [`Regex`](https://docs.rs/regex/latest/regex/struct.Regex.html)
 //! type is re-exported
@@ -104,6 +104,48 @@
 //!   );
 //!
 //!   Ok(())
+//! }
+//! ```
+//!
+//! Nested deserialization with recap can be achieved by having recap take over deriving [serde::Deserialize], which
+//! can be enabled with the `[recap(handle_deserialize)]` attribute. Note that you'll need to *not* include
+//! `#[derive(Deserialize)]` and that this currently doesn't support all of the features of serde's Deserialize
+//! derivation, such as zero-copy.
+//!
+//! ```rust
+//! use recap::Recap;
+//! use std::error::Error;
+//!
+//! #[derive(Debug, PartialEq, Recap)]
+//! #[recap(handle_deserialize, regex = r"(?P<foo>\w+):(?P<bar>\d+)")]
+//! struct Inner {
+//!     foo: String,
+//!     bar: u32,
+//! }
+//!
+//! #[derive(Debug, PartialEq, Recap)]
+//! #[recap(handle_deserialize, regex = r"(?P<first>[^ ]+)( (?P<second>[^ ]+))?")]
+//! struct Outer {
+//!     first: Inner,
+//!     second: Option<Inner>,
+//! }
+//!
+//! fn main() -> Result<(), Box<dyn Error>>  {
+//!     let outer: Outer = "abc:123 def:456".try_into().unwrap();
+//!     assert_eq!(
+//!         outer,
+//!         Outer {
+//!             first: Inner {
+//!                 foo: "abc".into(),
+//!                 bar: 123
+//!             },
+//!             second: Some(Inner {
+//!                 foo: "def".into(),
+//!                 bar: 456,
+//!             }),
+//!         }
+//!     );
+//!     Ok(())
 //! }
 //! ```
 pub use regex::Regex;

--- a/recap/tests/custom_deserialize_allows_nested_structs.rs
+++ b/recap/tests/custom_deserialize_allows_nested_structs.rs
@@ -1,0 +1,44 @@
+use recap::Recap;
+
+#[derive(Debug, Eq, PartialEq, Recap)]
+#[recap(handle_deserialize, regex = r"(?P<foo>\w+):(?P<bar>\d+)")]
+struct Inner {
+    foo: String,
+    bar: u32,
+}
+
+#[derive(Debug, Eq, PartialEq, Recap)]
+#[recap(handle_deserialize, regex = r"(?P<first>[^ ]+)( (?P<second>[^ ]+))?")]
+struct Outer {
+    first: Inner,
+    second: Option<Inner>,
+}
+
+#[test]
+fn custom_deserialize_allows_nested_structs() {
+    let outer: Outer = "abc:123 def:456".try_into().unwrap();
+    assert_eq!(
+        outer,
+        Outer {
+            first: Inner {
+                foo: "abc".to_owned(),
+                bar: 123
+            },
+            second: Some(Inner {
+                foo: "def".to_owned(),
+                bar: 456,
+            }),
+        }
+    );
+    let outer: Outer = "ghi:789".try_into().unwrap();
+    assert_eq!(
+        outer,
+        Outer {
+            first: Inner {
+                foo: "ghi".to_owned(),
+                bar: 789
+            },
+            second: None,
+        }
+    );
+}

--- a/recap/tests/custom_deserialize_preserves_serde_attributes.rs
+++ b/recap/tests/custom_deserialize_preserves_serde_attributes.rs
@@ -1,0 +1,32 @@
+use recap_derive::Recap;
+
+fn default_str() -> String {
+    "Some default".into()
+}
+
+#[derive(Debug, Eq, PartialEq, Recap)]
+#[recap(
+    handle_deserialize,
+    regex = r"((?P<FirstAttribute>\w+):)?(?P<second_rename>\d+):(?P<ThirdAttribute>\w+)"
+)]
+#[serde(rename_all = "PascalCase")]
+struct Test {
+    #[serde(default = "default_str")]
+    first_attribute: String,
+    #[serde(rename = "second_rename")]
+    second_attribute: u32,
+    third_attribute: String,
+}
+
+#[test]
+fn custom_deserialize_preserves_serde_attributes() {
+    let test = "42:non_default".parse::<Test>().unwrap();
+    assert_eq!(
+        test,
+        Test {
+            first_attribute: "Some default".into(),
+            second_attribute: 42,
+            third_attribute: "non_default".into(),
+        }
+    );
+}

--- a/recap/tests/custom_deserialize_works_with_other_formats.rs
+++ b/recap/tests/custom_deserialize_works_with_other_formats.rs
@@ -1,0 +1,64 @@
+use recap_derive::Recap;
+
+fn default_str() -> String {
+    "Some default".into()
+}
+
+#[derive(Debug, Eq, PartialEq, Recap)]
+#[recap(
+    handle_deserialize,
+    regex = r"((?P<FirstAttribute>\w+):)?(?P<second_rename>\d+):(?P<ThirdAttribute>\w+)"
+)]
+#[serde(rename_all = "PascalCase")]
+struct Inner {
+    #[serde(default = "default_str")]
+    first_attribute: String,
+    #[serde(rename = "second_rename")]
+    second_attribute: u32,
+    third_attribute: String,
+}
+
+#[derive(Debug, Eq, PartialEq, Recap)]
+#[recap(
+    handle_deserialize,
+    regex = r"(?P<first>[^ ]+)( (?P<second>[^ ]+))? (?P<third>[^ ]+)"
+)]
+struct Outer {
+    first: Inner,
+    second: Option<Inner>,
+    third: Option<Inner>,
+}
+
+#[test]
+fn custom_deserialize_works_with_other_formats() {
+    let raw_json = r#"
+        {
+            "first": {
+                "FirstAttribute": "first_first",
+                "second_rename": 123,
+                "ThirdAttribute": "first_third"
+            },
+            "third": {
+                "second_rename": 456,
+                "ThirdAttribute": "third_third"
+            }
+        }
+    "#;
+    let outer: Outer = serde_json::from_str(raw_json).unwrap();
+    assert_eq!(
+        outer,
+        Outer {
+            first: Inner {
+                first_attribute: "first_first".into(),
+                second_attribute: 123,
+                third_attribute: "first_third".into(),
+            },
+            second: None,
+            third: Some(Inner {
+                first_attribute: "Some default".into(),
+                second_attribute: 456,
+                third_attribute: "third_third".into(),
+            }),
+        }
+    )
+}

--- a/recap/tests/default_deserialize_works.rs
+++ b/recap/tests/default_deserialize_works.rs
@@ -1,0 +1,21 @@
+use recap_derive::Recap;
+use serde::Deserialize;
+
+#[derive(Debug, Eq, PartialEq, Deserialize, Recap)]
+#[recap(regex = r"(?P<first>\w+):(?P<second>\d+)")]
+struct Test {
+    first: String,
+    second: u32,
+}
+
+#[test]
+fn default_deserialize_works() {
+    let test = "hello:1337".parse::<Test>().unwrap();
+    assert_eq!(
+        test,
+        Test {
+            first: "hello".into(),
+            second: 1337
+        }
+    );
+}


### PR DESCRIPTION
## What did you implement:

This enables Recap to work for multiple layers of nested structs, as seen in the `custom_deserialize_allows_nested_structs` test. The impetus for this came from things like https://adventofcode.com/2023/day/19, where parsing the workflow with rules with optional conditions gets much easier if you can just describe it as 3 nested structs.

There's details on the implementation written in the `derive_impl_deserialize` function, but the high level is that, when enabled, this will create a helper struct that mirrors the original one and then handle most deserialization requests by first deserializing into the helper struct and then moving the data to an instance of the original struct. The main difference is custom behavior for `str`, which allows us to parse the `str` using the regex and *then* forward to the helper struct.

Note that currently the `Deserialize` implementation has some limitations like not working with zero-copy structs (structs that have lifetimes) or generic types (though generics already seems to not work with the existing Recap derivation). This also changes the `Recap` proc-macro to allow/handle `serde` attributes, which could lead to false negatives where people are putting attributes that end up being unused and not getting compiler warnings for it when the `handle_deserialize` attribute is *not* present. The only way around this that I'm aware of would be to use a different derive name (eg something like `#[derive(RecapDeserialize)]`) which I'm certainly open to as an alternative to the current `#[recap(handle_deserialize)]` approach if you'd prefer.

Closes: https://github.com/softprops/recap/issues/10

#### How did you verify your change:

This also adds integration tests for the derive definition and updates the documentation to describe the new behavior.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

The new behavior accessible via the `#[recap(handle_deserialize)]` attribute and likely the change in allowing `serde` attributes as well.