### PR TITLE
Fix `non_local_definitions` warning

### DIFF
--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -1,11 +1,10 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use quote::quote;
 use regex::Regex;
 use syn::{
-    parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta,
+    parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields, Lit, Meta, NestedMeta,
 };
 
 #[proc_macro_derive(Recap, attributes(recap))]
@@ -75,13 +74,8 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
         }
     };
 
-    let injector = Ident::new(
-        &format!("RECAP_IMPL_FOR_{}", item.ident.to_string()),
-        Span::call_site(),
-    );
-
     let out = quote! {
-        const #injector: () = {
+        const _: () = {
             extern crate recap;
             #impl_inner
             #impl_matcher


### PR DESCRIPTION
On nightly compiler, I'm getting:

```
  --> y2015\src\bin\solution_2015_09.rs:10:30
   |
10 | #[derive(Debug, Deserialize, Recap, Clone)]
   |                              ^----
   |                              |
   |                              move the `impl` block outside of this constant `RECAP_IMPL_FOR_Route`
11 | #[recap(regex = r#"^(?P<f>[A-Za-z]+) to (?P<t>[A-Za-z]+) = (?P<d>\d+)$"#)]
12 | struct Route {
   |        ----- `Route` is not local
   |
   = note: the derive macro `Recap` defines the non-local `impl`, and may need to be changed
   = note: the derive macro `Recap` may come from an old version of the `recap_derive` crate, try updating your dependency with `cargo update -p recap_derive`
   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
   = note: this warning originates in the derive macro `Recap` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
```

This is an attempt to fix it.